### PR TITLE
fixed missing semicolons

### DIFF
--- a/src/flextree.js
+++ b/src/flextree.js
@@ -1,7 +1,7 @@
 import {hierarchy} from 'd3-hierarchy';
 import packageInfo from '../package.json';
 
-const {version} = packageInfo 
+const {version} = packageInfo;
 const defaults = Object.freeze({
   children: data => data.children,
   nodeSize: node => node.data.size,

--- a/src/test/api-tests.js
+++ b/src/test/api-tests.js
@@ -2,7 +2,7 @@ import {flextree} from '../../index.js';
 import {hierarchy} from 'd3-hierarchy';
 import packageInfo from '../../package.json';
 
-const {version} = packageInfo
+const {version} = packageInfo;
 // Several different ways of representing the same tree.
 export const treeData = {
   default: {


### PR DESCRIPTION
fixed missing semi-colons from previous commit #50fdf91 from avs-doom

causing webpack-dev-server in webpack 5 to error based on eslint config settings requiring semi-colons.